### PR TITLE
added generalized_parameter_translation.json

### DIFF
--- a/technical-metadata/search-metadata/generalized_paramter_translation.json
+++ b/technical-metadata/search-metadata/generalized_paramter_translation.json
@@ -1,0 +1,80 @@
+[
+    {
+        // "<internal ID, numeric, continous>"
+        "_id" : 42, 
+        // <paramter name translations>
+        "msgfplus_style_1"  : "-t",
+        "xtandem_style_1"   : "spectrum, parent monoisotopic mass error units",
+        "msfragger_style_1" : "precursor_mass_units",
+        "searchgui_style_1" : "-prec_ppm",
+        "psi_ms_style_1"    : ["MS:1001412", "MS:1001413"],
+        "ursgal_style_1"    : "precursor_mass_tolerance_unit",
+        "description"       : "Precursor mass tolerance unit",
+        // <paramtervalue translations>
+        "value_translations" : {
+            "msgfplus_style_1" : {"da"  : "Da"},
+            "xtandem_style_1" : {"da"  : "Daltons"},
+            "msfragger_style_1" : {"ppm" : 1, "da"  : 0},
+            "searchgui_style_1": {"ppm" : 1, "da"  : 0},
+            "psi_ms_style_1" : {"da": "UO:0000221", "ppm": "UO:0000169"}
+        },
+        "value_type": "str"
+    },
+    {
+        "_id": 123,
+        "msgfplus_style_1"  : "-minLength",
+        "msfragger_style_1" : "digest_min_length",
+        "psi_ms_style_1"    : "MS:1002322",
+        // this parameter maps on multiple SearchGUI parameters
+        // one solution to deal with this would be a list
+        // depending on how SearchGUI deals with e.g. setting msgf_min_pep_length
+        // without actually running msgfplus
+        "searchgui_style_1" : [
+            "-myrimatch_min_pep_length",
+            "-msgf_min_pep_length",
+            "-omssa_min_pep_length",
+            "-tide_min_pep_length",
+            "-andromeda_min_pep_length"
+        ],
+        // a second solution would be a format string
+        // where the engine (that will be used) is filled in by SearchGUI
+        "searchgui_style_2" : "-{engine}_min_pep_length",
+        "ursgal_style_1" : "min_pep_length",
+        "description" : "Minimum peptide length",
+        "value_translations":{},
+        "value_type" : "int"
+    },
+    // <definition of engine styles/versions> 
+    // required for each style
+    {
+        "msgfplus_style_1" : {
+            "name" : "MS-GF+",
+            "version" : [
+                "v2018.01.20",
+                "v2018.06.28",
+                "v2018.09.12",
+            ],
+            "reference" : "Kim S, Mischerikow N, Bandeira N, Navarro JD, Wich L, 'Mohammed S, Heck AJ, Pevzner PA. (2010) The Generating Function of CID, ETD, and CID/ETD Pairs of Tandem Mass Spectra: Applications to Database Search."
+        },
+        "msfragger_style_1" : {
+            "name" : "MSFragger",
+            "version" : [
+                "20170103",
+            ],
+            "reference" : "Kong, A. T., Leprevost, F. V, Avtonomov, D. M., Mellacheruvu, D., and Nesvizhskii, A. I. (2017) MSFragger: ultrafast and comprehensive peptide identification in mass spectrometry-based proteomics. Nature Methods 14",
+        },
+        "ursgal_style_1" : {
+            "name" : "Ursgal",
+            "version" : [
+                "0.6.0",
+                "0.6.1",
+            ],
+            "reference" : "Kremer, L. P. M., Leufken, J., Oyunchimeg, P., Schulze, S. & Fufezan, C. (2016) Ursgal, Universal Python Module Combining Common Bottom-Up Proteomics Tools for Large-Scale Analysis. J. Proteome res. 15, 788-794.",
+        },
+        "searchgui_style_1" : {},
+        "searchgui_style_2" : {},
+        "psi_ms_style_1" : {},
+        "xtandem_style_1" : {}
+    }
+
+ ]


### PR DESCRIPTION
We (the Ursgal team) have added an example .json file for how a generalized parameter translation repository could look like.
This is open for discussion/changes and only includes two parameters as examples so far. Comments are indicated by // (although the json format doesn't support comments - it's just supposed to make discussions easier)