### PR TITLE
Proposal for encoding Enzyme information into SDRF. 

### DIFF
--- a/experimental-design/ENZYMES.tsv
+++ b/experimental-design/ENZYMES.tsv
@@ -1,0 +1,21 @@
+NE=2-iodobenzoate; CS='(?<=W)'
+NE=Arg-C; CS='(?<=R)(?\!P)'
+NE=Asp-N; CS='(?=[BD])'
+NE=Asp-N ambic;  CS='(?=[DE])'
+NE=CNBr; CS='(?<=M)'
+NE=Chymotrypsin;  CS='(?<=[FYWL])(?\!P)'
+NE=Formic acid; CS='((?<=D))|((?=D))'
+NE=Lys-C;  CS='(?<=K)(?\!P)'
+NE=Lys-C/P; CS='(?<=K)'
+NE=PepsinA; CS='(?<=[FL])'
+NE=TrypChymo; CS='(?<=[FYWLKR])(?\!P)'
+NE=Trypsin; CS='(?<=[KR])(?\!P)'
+NE=Trypsin/P; CS='(?<=[KR])'
+NE=V8-DE; CS='(?<=[BDEZ])(?\!P)'
+NE=V8-E; CS='(?<=[EZ])(?\!P)'
+NE=glutamyl endopeptidase; CS='(?<=[^E]E)'
+NE=leukocyte elastase; CS='(?<=[ALIV])(?!P)'
+NE=proline endopeptidase; CS='(?<=[HKR]P)(?!P)'
+
+
+

--- a/experimental-design/README.adoc
+++ b/experimental-design/README.adoc
@@ -161,7 +161,7 @@ The RECOMMENDED name of the column for sample modification parameters is:
 
   Comment [modification parameters]
 
-.. NOTE: The `modification parameters` is the name of the ontology term https://www.ebi.ac.uk/ols/ontologies/ms/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FMS_1001055[MS:1001055]
+NOTE: The `modification parameters` is the name of the ontology term https://www.ebi.ac.uk/ols/ontologies/ms/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FMS_1001055[MS:1001055]
 
 For each modification, we will capture different properties in a `key=value` pair structure including name, position, etc. All the possible features available for modification parameters:
 
@@ -175,7 +175,7 @@ For each modification, we will capture different properties in a `key=value` pai
 
 |Chemical Formula  | CF | CF=H(2)C(2)O| Optional | This is the chemical formula of the added or removed atoms. For the formula composition please follow the guidelines from http://www.unimod.org/names.html[UNIMOD]
 
-|Modification type | MT | MT=Fixed | Required | This specifies which modification group the modification should be included with. Choose from the following options: [Fixed, Variable, Custom, Annotated].
+|Modification type | MT | MT=Fixed | Required | This specifies which modification group the modification should be included with. Choose from the following options: [Fixed, Variable, Custom, Annotated]. _Annotated_ is use to search for all the occurrences of the modification into an annotated protein database file like UNIPROT XML or PEEF.
 
 |Position of the modification in the polypeptide |  PP | PP=Any N-term | Required | Choose from the following options: [Anywhere, Protein N-term, Protein C-term, Any N-term, Any C-term]
 
@@ -189,15 +189,36 @@ For each modification, we will capture different properties in a `key=value` pai
 
 ..NOTE: We RECOMMEND for the modification name the UNIMOD interim name or PSI-MOD name if they are use. For custom modifications, we RECOMMEND an intuitive name.
 
-Some examples of **SDRF** with sample modifications annotated:
-
+An example of a **SDRF** with sample modifications annotated:
 
 |===
-| |comment [modification parameters] | comment [modification parameters]
+| |Comment [modification parameters] | Comment [modification parameters]
 
 |sample 1| NM=Glu->pyro-Glu; MT=fixed; PP=Anywhere; AC=Unimod:27; TA=E | NM=Oxidation; MT=Variable; TA=M
 |===
 
+[[encoding-enzymes]]
+=== Enzyme
+
+The `Comment [cleavage agent details]` property is used to capture the Enzyme information. Similar to protein modification <<encoding-protein-modifications>> we will use a key=value pair representation to encode the following properties for each enzyme:
+
+|===
+|Property |Key |Example | Required/Optional | Comment
+
+|Name of the Enzyme | NE | NM=Trypsin | Required | * Name of the Enzyme.
+
+|Database Accession| AC | AC=MS:1001251 | Optional | Accession in an external PSI-MS Ontology definition under the following category https://www.ebi.ac.uk/ols/ontologies/ms/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FMS_1001045[Cleavage agent name].
+
+|Cleavage site regular expression | CS | CS=(?<=[KR]) | Optional | The cleavage site defined as a regular expression.
+|===
+
+An example of a **SDRF** with sample enzyme annotated:
+
+|===
+| |Comment [cleavage agent details]
+
+|sample 1| NE=Trypsin; AC=MS:1001251; CS=(?<=[KR])
+|===
 
 
 [[encoding-tolerances]]
@@ -205,7 +226,3 @@ Some examples of **SDRF** with sample modifications annotated:
 
 Pending
 
-[[encoding-enzymes]]
-=== Enzyme
-
-Pending

--- a/experimental-design/README.adoc
+++ b/experimental-design/README.adoc
@@ -175,7 +175,7 @@ For each modification, we will capture different properties in a `key=value` pai
 
 |Chemical Formula  | CF | CF=H(2)C(2)O| Optional | This is the chemical formula of the added or removed atoms. For the formula composition please follow the guidelines from http://www.unimod.org/names.html[UNIMOD]
 
-|Modification type | MT | MT=Fixed | Required | This specifies which modification group the modification should be included with. Choose from the following options: [Fixed, Variable, Custom, Annotated]. _Annotated_ is used to search for all the occurrences of the modification into an annotated protein database file like UNIPROT XML or PEEF.
+|Modification type | MT | MT=Fixed | Required | This specifies which modification group the modification should be included with. Choose from the following options: [Fixed, Variable, Custom, Annotated]. _Annotated_ is used to search for all the occurrences of the modification into an annotated protein database file like UNIPROT XML or PEFF.
 
 |Position of the modification in the polypeptide |  PP | PP=Any N-term | Required | Choose from the following options: [Anywhere, Protein N-term, Protein C-term, Any N-term, Any C-term]
 

--- a/experimental-design/README.adoc
+++ b/experimental-design/README.adoc
@@ -175,7 +175,7 @@ For each modification, we will capture different properties in a `key=value` pai
 
 |Chemical Formula  | CF | CF=H(2)C(2)O| Optional | This is the chemical formula of the added or removed atoms. For the formula composition please follow the guidelines from http://www.unimod.org/names.html[UNIMOD]
 
-|Modification type | MT | MT=Fixed | Required | This specifies which modification group the modification should be included with. Choose from the following options: [Fixed, Variable, Custom, Annotated]. _Annotated_ is use to search for all the occurrences of the modification into an annotated protein database file like UNIPROT XML or PEEF.
+|Modification type | MT | MT=Fixed | Required | This specifies which modification group the modification should be included with. Choose from the following options: [Fixed, Variable, Custom, Annotated]. _Annotated_ is used to search for all the occurrences of the modification into an annotated protein database file like UNIPROT XML or PEEF.
 
 |Position of the modification in the polypeptide |  PP | PP=Any N-term | Required | Choose from the following options: [Anywhere, Protein N-term, Protein C-term, Any N-term, Any C-term]
 

--- a/experimental-design/README.adoc
+++ b/experimental-design/README.adoc
@@ -209,7 +209,7 @@ The `Comment [cleavage agent details]` property is used to capture the Enzyme in
 
 |Database Accession| AC | AC=MS:1001251 | Optional | Accession in an external PSI-MS Ontology definition under the following category https://www.ebi.ac.uk/ols/ontologies/ms/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FMS_1001045[Cleavage agent name].
 
-|Cleavage site regular expression | CS | CS=(?<=[KR]) | Optional | The cleavage site defined as a regular expression.
+|Cleavage site regular expression | CS | CS=(?<=[KR])(?!P) | Optional | The cleavage site defined as a regular expression.
 |===
 
 An example of a **SDRF** with sample enzyme annotated:
@@ -217,7 +217,7 @@ An example of a **SDRF** with sample enzyme annotated:
 |===
 | |Comment [cleavage agent details]
 
-|sample 1| NE=Trypsin; AC=MS:1001251; CS=(?<=[KR])
+|sample 1| NE=Trypsin; AC=MS:1001251; CS=(?<=[KR])(?!P)
 |===
 
 


### PR DESCRIPTION
The following PR added new information about how to encode the Enzyme used into an **SDRF**: 

- It will follow the same approach that PTM information as key=value pairs. 
- It will enable to encode custom enzymes as long as well-annotated enzymes in PSI-MS. 

Pending discussion: How to encode as regular expressions the Target Site in the sequence. 